### PR TITLE
11 featuring rename file button

### DIFF
--- a/web_server/public/stylesheets/style.css
+++ b/web_server/public/stylesheets/style.css
@@ -47,6 +47,15 @@ a {
     font-style: italic;
 }
 
+#fileType {
+    padding: 1.25rem 0.75rem 0;
+    align-self: flex-start;
+}
+
+#temp {
+    width: 100%;
+}
+
 td.icon,
 td.dropdown > a {
     padding-left: 0;

--- a/web_server/routes/index.js
+++ b/web_server/routes/index.js
@@ -145,6 +145,7 @@ router.post('/:dst/:src/copy', async (req, res, next) => {
     }
 });
 
+// File duplicate Route
 router.post('/:dst/:src/dup', async (req, res, next) => {
     try {
         const src_dir = '/' + req.params.src;
@@ -155,6 +156,22 @@ router.post('/:dst/:src/dup', async (req, res, next) => {
         console.log(dst_dir);
         let client = new TCPClient({ port: tcp_server.port, host: tcp_server.host });
         let msg = await client.copy_file(src_dir, dst_dir);
+        console.log(msg);
+        client.socket.destroy();
+        res.status(200).end();
+    } catch (err) {
+        console.log(err);
+        client.socket.destroy();
+    }
+});
+
+// File rename Route
+router.put('/:src/:dst/rename', async (req, res, next) => {
+    try {
+        const src_dir = '/' + req.params.src;
+        const dst_dir = '/' + path.dirname(req.params.src) + '/' + req.params.dst;
+        let client = new TCPClient({ port: tcp_server.port, host: tcp_server.host });
+        let msg = await client.rename_file(src_dir, dst_dir);
         console.log(msg);
         client.socket.destroy();
         res.status(200).end();

--- a/web_server/views/index.pug
+++ b/web_server/views/index.pug
@@ -33,6 +33,23 @@ html(lang="en")
         .d-flex 
           .toast-body
           button(type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast")
+    .modal.fade(data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="renameModalLabel" aria-hidden="true")#renameModal
+      .modal-dialog.modal-dialog-centered
+        .modal-content
+          .modal-header 
+            h5.modal-title#modalTitle
+            button(type="button" data-bs-dismiss="modal" aria-label="Close").btn-close
+          .modal-body
+            form.needs-validation
+              .mb-3.d-flex
+                .form-floating#temp
+                  input(type="text")#newName.form-control
+                  label(for="newName") New Name
+                  .invalid-feedback.ms-2#invalidFileName
+                span#fileType
+          .modal-footer
+            button(type="button" data-bs-dismiss="modal").btn.btn-secondary Close
+            button(type="button" disabled)#renameBtn.btn.btn-primary Rename
     script(src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js")
     script(src="https://code.jquery.com/jquery-1.12.4.min.js") 
     script.


### PR DESCRIPTION
Feat: file rename button

File rename button created.
Bootstrap modal used for file rename.
Move button, copy button disabled after rename.
Move and copy button disable each other when clicked.

modified:   public/javascripts/index.js
modified:   public/stylesheets/style.css
modified:   routes/index.js
modified:   views/index.pug